### PR TITLE
Fix bug with asynchrony in useUpdatePassword hook

### DIFF
--- a/lib/apollo/hooks/actions/auth.js
+++ b/lib/apollo/hooks/actions/auth.js
@@ -127,20 +127,21 @@ export const usePasswordRecovery = () => {
 
   const [mutation, mutationState] = useMutation(RequestPasswordRecovery);
 
-  const mutate = ({ email }) => {
+  const mutate = async ({ email }) => {
     const requestPasswordRecoveryInput = { email };
+
     try {
-      return mutation({ variables: { input: requestPasswordRecoveryInput } });
+      return await mutation({ variables: { input: requestPasswordRecoveryInput } });
     } catch (error) {
       setError(error);
       return null;
     }
   };
 
-  const errorMessage = mutationState?.error;
+  const error = mutationState?.error;
   const detail = mutationState?.data?.requestPasswordRecovery?.detail;
 
-  return [mutate, detail, errorMessage];
+  return [mutate, detail, error];
 };
 
 export const useUpdateUser = () => {


### PR DESCRIPTION
# Summary

#### - fixed bug in auth.js with asynchrony in useUpdatePassword hook
#### - replaced `mutationState.messageError` to `mutationState.error` in `usePasswordRecovery` hook - because of the decorator in depth we don't get errorMessage, but error





