### PR TITLE
[249] Rename HOCs, add withRedirectIfLoggedIn HOC for auth pages

### DIFF
--- a/components/pages/activity/ActivityPage.tsx
+++ b/components/pages/activity/ActivityPage.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 
 import withAuth from 'lib/auth/withAuth';
-import WithAuthSecurity from 'lib/auth/withAuthSecurity';
+import withAuthSecurity from 'lib/auth/withAuthSecurity';
 import { withApolloClient } from 'lib/withApolloClient';
 import { useActivity } from 'lib/apollo/hooks/state/activity';
 import parseApolloError from 'lib/apollo/parseApolloError';
@@ -97,4 +97,4 @@ const Activity = () => {
   );
 };
 
-export default withApolloClient(withAuth(WithAuthSecurity(Activity)));
+export default withApolloClient(withAuth(withAuthSecurity(Activity)));

--- a/components/pages/activity/ActivityPage.tsx
+++ b/components/pages/activity/ActivityPage.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useState } from 'react';
 
-import WithAuth from 'lib/auth/withAuth';
+import withAuth from 'lib/auth/withAuth';
 import WithAuthSecurity from 'lib/auth/withAuthSecurity';
 import { withApolloClient } from 'lib/withApolloClient';
 import { useActivity } from 'lib/apollo/hooks/state/activity';
@@ -97,4 +97,4 @@ const Activity = () => {
   );
 };
 
-export default withApolloClient(WithAuth(WithAuthSecurity(Activity)));
+export default withApolloClient(withAuth(WithAuthSecurity(Activity)));

--- a/components/pages/home/HomePage.tsx
+++ b/components/pages/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import WithAuth from 'lib/auth/withAuth';
+import withAuth from 'lib/auth/withAuth';
 import { withApolloClient } from 'lib/withApolloClient';
 
 import DefaultTemplate from 'components/shared/templates/DefaultTemplate';
@@ -20,4 +20,4 @@ const HomePage = () => {
   );
 };
 
-export default withApolloClient(WithAuth(HomePage));
+export default withApolloClient(withAuth(HomePage));

--- a/components/pages/profile/ProfilePage.tsx
+++ b/components/pages/profile/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import ErrorMessage from 'components/shared/atoms/ErrorMessage';
 import withAuth from 'lib/auth/withAuth';
-import WithAuthSecurity from 'lib/auth/withAuthSecurity';
+import withAuthSecurity from 'lib/auth/withAuthSecurity';
 import { withApolloClient } from 'lib/withApolloClient';
 import { useCurrentUser } from 'lib/apollo/hooks/state/currentUser';
 import parseApolloError from 'lib/apollo/parseApolloError';
@@ -34,4 +34,4 @@ const Profile = () => {
   );
 };
 
-export default withApolloClient(withAuth(WithAuthSecurity(Profile)));
+export default withApolloClient(withAuth(withAuthSecurity(Profile)));

--- a/components/pages/profile/ProfilePage.tsx
+++ b/components/pages/profile/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import ErrorMessage from 'components/shared/atoms/ErrorMessage';
-import WithAuth from 'lib/auth/withAuth';
+import withAuth from 'lib/auth/withAuth';
 import WithAuthSecurity from 'lib/auth/withAuthSecurity';
 import { withApolloClient } from 'lib/withApolloClient';
 import { useCurrentUser } from 'lib/apollo/hooks/state/currentUser';
@@ -34,4 +34,4 @@ const Profile = () => {
   );
 };
 
-export default withApolloClient(WithAuth(WithAuthSecurity(Profile)));
+export default withApolloClient(withAuth(WithAuthSecurity(Profile)));

--- a/components/pages/recoveryPassword/RecoveryPasswordPage.tsx
+++ b/components/pages/recoveryPassword/RecoveryPasswordPage.tsx
@@ -1,7 +1,7 @@
 import Router from 'next/router';
 
 import { withApolloClient } from 'lib/withApolloClient';
-import WithAuth from 'lib/auth/withAuth';
+import withAuth from 'lib/auth/withAuth';
 import { PageContext } from 'types/pageContextInterfaces';
 
 import { HOME } from 'config/routes';
@@ -39,4 +39,4 @@ RecoveryPasswordPage.getInitialProps = ({ res, accessTokenManager }: PageContext
   return {};
 };
 
-export default withApolloClient(WithAuth(RecoveryPasswordPage));
+export default withApolloClient(withAuth(RecoveryPasswordPage));

--- a/components/pages/recoveryPassword/RecoveryPasswordPage.tsx
+++ b/components/pages/recoveryPassword/RecoveryPasswordPage.tsx
@@ -1,10 +1,7 @@
-import Router from 'next/router';
-
 import { withApolloClient } from 'lib/withApolloClient';
 import withAuth from 'lib/auth/withAuth';
-import { PageContext } from 'types/pageContextInterfaces';
+import withRedirectIfLoggedIn from 'lib/auth/withRedirectIfLoggedIn';
 
-import { HOME } from 'config/routes';
 import { NotifierProvider } from 'contexts/NotifierContext';
 
 import DefaultTemplate from 'components/shared/templates/DefaultTemplate';
@@ -27,16 +24,4 @@ const RecoveryPasswordPage = () => {
   );
 };
 
-RecoveryPasswordPage.getInitialProps = ({ res, accessTokenManager }: PageContext) => {
-  if (accessTokenManager?.accessToken) {
-    if (res) {
-      res.writeHead(302, { Location: HOME });
-      res.end();
-    } else {
-      Router.push(HOME);
-    }
-  }
-  return {};
-};
-
-export default withApolloClient(withAuth(RecoveryPasswordPage));
+export default withApolloClient(withAuth(withRedirectIfLoggedIn(RecoveryPasswordPage)));

--- a/components/pages/signIn/SignInPage.tsx
+++ b/components/pages/signIn/SignInPage.tsx
@@ -1,10 +1,7 @@
-import Router from 'next/router';
-
 import { withApolloClient } from 'lib/withApolloClient';
 import withAuth from 'lib/auth/withAuth';
-import { PageContext } from 'types/pageContextInterfaces';
+import withRedirectIfLoggedIn from 'lib/auth/withRedirectIfLoggedIn';
 
-import { HOME } from 'config/routes';
 import { NotifierProvider } from 'contexts/NotifierContext';
 
 import DefaultTemplate from 'components/shared/templates/DefaultTemplate';
@@ -27,16 +24,4 @@ const SignInPage = () => {
   );
 };
 
-SignInPage.getInitialProps = ({ res, accessTokenManager }: PageContext) => {
-  if (accessTokenManager?.accessToken) {
-    if (res) {
-      res.writeHead(302, { Location: HOME });
-      res.end();
-    } else {
-      Router.push(HOME);
-    }
-  }
-  return {};
-};
-
-export default withApolloClient(withAuth(SignInPage));
+export default withApolloClient(withAuth(withRedirectIfLoggedIn(SignInPage)));

--- a/components/pages/signUp/SignUpPage.tsx
+++ b/components/pages/signUp/SignUpPage.tsx
@@ -1,7 +1,7 @@
 import Router from 'next/router';
 
 import { withApolloClient } from 'lib/withApolloClient';
-import WithAuth from 'lib/auth/withAuth';
+import withAuth from 'lib/auth/withAuth';
 import { PageContext } from 'types/pageContextInterfaces';
 
 import { HOME } from 'config/routes';
@@ -39,4 +39,4 @@ SignUpPage.getInitialProps = ({ res, accessTokenManager }: PageContext) => {
   return {};
 };
 
-export default withApolloClient(WithAuth(SignUpPage));
+export default withApolloClient(withAuth(SignUpPage));

--- a/components/pages/signUp/SignUpPage.tsx
+++ b/components/pages/signUp/SignUpPage.tsx
@@ -1,10 +1,7 @@
-import Router from 'next/router';
-
 import { withApolloClient } from 'lib/withApolloClient';
 import withAuth from 'lib/auth/withAuth';
-import { PageContext } from 'types/pageContextInterfaces';
+import withRedirectIfLoggedIn from 'lib/auth/withRedirectIfLoggedIn';
 
-import { HOME } from 'config/routes';
 import { NotifierProvider } from 'contexts/NotifierContext';
 
 import DefaultTemplate from 'components/shared/templates/DefaultTemplate';
@@ -27,16 +24,4 @@ const SignUpPage = () => {
   );
 };
 
-SignUpPage.getInitialProps = ({ res, accessTokenManager }: PageContext) => {
-  if (accessTokenManager?.accessToken) {
-    if (res) {
-      res.writeHead(302, { Location: HOME });
-      res.end();
-    } else {
-      Router.push(HOME);
-    }
-  }
-  return {};
-};
-
-export default withApolloClient(withAuth(SignUpPage));
+export default withApolloClient(withAuth(withRedirectIfLoggedIn(SignUpPage)));

--- a/lib/auth/withAuth.js
+++ b/lib/auth/withAuth.js
@@ -1,7 +1,7 @@
-import WithAuthSyncEvents from './withAuthSyncEvents';
+import withAuthSyncEvents from './withAuthSyncEvents';
 import WithTokensUpdate from './withTokensUpdate';
 
 // combine necessary auth HOC's
-const withAuth = (Page) => WithTokensUpdate(WithAuthSyncEvents(Page));
+const withAuth = (Page) => WithTokensUpdate(withAuthSyncEvents(Page));
 
 export default withAuth;

--- a/lib/auth/withAuth.js
+++ b/lib/auth/withAuth.js
@@ -1,7 +1,7 @@
 import withAuthSyncEvents from './withAuthSyncEvents';
-import WithTokensUpdate from './withTokensUpdate';
+import withTokensUpdate from './withTokensUpdate';
 
 // combine necessary auth HOC's
-const withAuth = (Page) => WithTokensUpdate(withAuthSyncEvents(Page));
+const withAuth = (Page) => withTokensUpdate(withAuthSyncEvents(Page));
 
 export default withAuth;

--- a/lib/auth/withAuth.js
+++ b/lib/auth/withAuth.js
@@ -2,6 +2,6 @@ import WithAuthSyncEvents from './withAuthSyncEvents';
 import WithTokensUpdate from './withTokensUpdate';
 
 // combine necessary auth HOC's
-const WithAuth = (Page) => WithTokensUpdate(WithAuthSyncEvents(Page));
+const withAuth = (Page) => WithTokensUpdate(WithAuthSyncEvents(Page));
 
-export default WithAuth;
+export default withAuth;

--- a/lib/auth/withAuthSecurity.jsx
+++ b/lib/auth/withAuthSecurity.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { SIGNIN } from 'config/routes';
 
-const WithAuthSecurity = (Page) =>
+const withAuthSecurity = (Page) =>
   class WithAuthSecurityClass extends Component {
     static async getInitialProps(context) {
       const { req, res, accessTokenManager } = context;
@@ -22,4 +22,4 @@ const WithAuthSecurity = (Page) =>
     }
   };
 
-export default WithAuthSecurity;
+export default withAuthSecurity;

--- a/lib/auth/withAuthSyncEvents.jsx
+++ b/lib/auth/withAuthSyncEvents.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 
 import { SIGN_IN_EVENT, SIGN_OUT_EVENT } from 'config/globalEvents.json';
 
-const WithAuthSyncEvents = (Page) =>
+const withAuthSyncEvents = (Page) =>
   class WithAuthSync extends Component {
     static async getInitialProps(context) {
       return Page.getInitialProps ? Page.getInitialProps(context) : {};
@@ -29,4 +29,4 @@ const WithAuthSyncEvents = (Page) =>
     }
   };
 
-export default WithAuthSyncEvents;
+export default withAuthSyncEvents;

--- a/lib/auth/withRedirectIfLoggedIn.tsx
+++ b/lib/auth/withRedirectIfLoggedIn.tsx
@@ -1,0 +1,37 @@
+import { NextPage } from 'next';
+import { Component } from 'react';
+import Router from 'next/router';
+import { PageContext } from 'types/pageContextInterfaces';
+import { HOME } from 'config/routes';
+
+const withRedirectIfLoggedIn = (Page: NextPage) => {
+  class WithRedirectIfLoggedIn extends Component {
+    static async getInitialProps(context: PageContext) {
+      const { res, accessTokenManager } = context;
+
+      if (accessTokenManager?.accessToken) {
+        if (res) {
+          res.writeHead(302, { Location: HOME });
+          res.end();
+        } else {
+          await Router.push(HOME);
+        }
+      }
+
+      let componentProps = {};
+      if (Page.getInitialProps) {
+        componentProps = Page.getInitialProps(context);
+      }
+
+      return componentProps;
+    }
+
+    render() {
+      return <Page {...this.props} />;
+    }
+  }
+
+  return WithRedirectIfLoggedIn;
+};
+
+export default withRedirectIfLoggedIn;

--- a/lib/auth/withTokensUpdate.jsx
+++ b/lib/auth/withTokensUpdate.jsx
@@ -29,7 +29,7 @@ const hasUserData = (apolloClient) => {
   }
 };
 
-const WithTokensUpdate = (Page) =>
+const withTokensUpdate = (Page) =>
   class WithTokensUpdateClass extends Component {
     static async getInitialProps(context) {
       const { req, res, apolloClient } = context;
@@ -85,4 +85,4 @@ const WithTokensUpdate = (Page) =>
     }
   };
 
-export default WithTokensUpdate;
+export default withTokensUpdate;


### PR DESCRIPTION
# Summary

#### A brief description of the pull request.

#### Resolves: #249 

#### Screenshots in case of UI changes

# Test plan

#### List of steps to manually test introduced functionality:

- Go to app locally, login
- try to go to /signin, /signup, /recovery-password pages
- You should been redirected to home page back 

#### What do need to pay more attention to, some implicit changes that influence the app:

- ...

# Review notes

#### While reviewing pull-request (especially when it's your pull-request), please make sure that:

- you named PR close to issue name and linked that issue
- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes
